### PR TITLE
resolve global user display issue

### DIFF
--- a/accounts/templates/accounts/profile.html
+++ b/accounts/templates/accounts/profile.html
@@ -15,7 +15,9 @@
     <p>EMAIL        :   {{ user.email }}</p>
     <p>PHONE NUMBER :   {{ user.userprofile.phone }}</p>
 {#    <p>PASSWORD(encrypted)     :   {{ user.password }}</p>#}
+        {% if user.userprofile.image %}
         <img src="{{ user.userprofile.image.url }}" width="240">
+        {% endif %}
 
     </div>
 {% endblock %}

--- a/home/views.py
+++ b/home/views.py
@@ -21,7 +21,7 @@ class HomeView(TemplateView):
     def get(self, request):
         form = HomeForm()
         posts = Post.objects.all().order_by('-date')
-        users = User.objects.all()
+        users = User.objects.exclude(id=request.user.id)
         args = {'form': form, 'posts': posts, 'users': users}
         return render(request, self.template_name, args)
 


### PR DESCRIPTION
The previous commit had a small issue while creating the "other people" div section in the homepage.
It displayed all the users in the website but also the name of the currently logged in user, which is not supposed to happen.

What is to be expected?
To remove the link of the currently active user from the "Other People tag"

Has the change been achieved?
Yes